### PR TITLE
Create landing and blog experience

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Lantern-Logic
+# Lantern Logic Journal
+
+A modern, magazine-style blog inspired by MIT Technology Review. The project features a gatekeeper landing page, a responsive blog index with hero and feature stories, and individual article pages populated with sample content.
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Run the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+3. Open [http://localhost:3000](http://localhost:3000) to view the site. The landing page leads into the blog experience with clickable tiles for each story.
+
+## Available Scripts
+
+- `npm run dev` – start the Next.js development server.
+- `npm run build` – create a production build.
+- `npm run start` – run the production build.
+- `npm run lint` – lint the project with Next.js ESLint configuration.

--- a/components/BlogHeader.tsx
+++ b/components/BlogHeader.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import styles from '@/styles/BlogHeader.module.css';
+
+export default function BlogHeader() {
+  return (
+    <header className={styles.header}>
+      <div className={styles.branding}>
+        <Link href="/blog">
+          <span className={styles.logo}>Lantern Logic</span>
+        </Link>
+        <p className={styles.tagline}>Tech, design, and climate stories for the curious.</p>
+      </div>
+      <nav className={styles.nav} aria-label="Primary">
+        <Link href="/blog#features">Features</Link>
+        <Link href="/blog#signals">Signals</Link>
+        <Link href="/blog#dispatches">Dispatches</Link>
+      </nav>
+    </header>
+  );
+}

--- a/components/BlogHeader.tsx
+++ b/components/BlogHeader.tsx
@@ -11,9 +11,10 @@ export default function BlogHeader() {
         <p className={styles.tagline}>Tech, design, and climate stories for the curious.</p>
       </div>
       <nav className={styles.nav} aria-label="Primary">
-        <Link href="/blog#features">Features</Link>
-        <Link href="/blog#signals">Signals</Link>
+        <Link href="/blog#spotlight">Spotlight</Link>
+        <Link href="/blog#features">Top Stories</Link>
         <Link href="/blog#dispatches">Dispatches</Link>
+        <Link href="/blog#signals">Signals</Link>
       </nav>
     </header>
   );

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,0 +1,121 @@
+export interface Post {
+  slug: string;
+  title: string;
+  excerpt: string;
+  content: string[];
+  category: string;
+  readTime: string;
+  publishedAt: string;
+  mood: 'hero' | 'feature' | 'quick';
+  accent: string;
+  gradient: string;
+}
+
+export const posts: Post[] = [
+  {
+    slug: 'synthetic-sunrises',
+    title: 'Synthetic Sunrises: Designing the Mood of Smart Cities',
+    excerpt:
+      'Urban planners are programming artificial dawns to keep megacities in sync. Can code make mornings feel more human?',
+    content: [
+      'As global cities rise vertically, natural light becomes a premium amenity. Designers are responding with synthetic skylines — programmable facades that bloom into sunrise gradients before commuters pour into the streets.',
+      'The Lantern Logic team embedded with Seoul’s newest “always dawn” district to understand how circadian lighting is woven into transit, wellness, and retail moments. Residents receive a personalized color temperature blend based on sleep history, while public plazas pivot to cooler palettes once afternoon productivity should spike.',
+      'Yet the soft glow hides hard questions: Who controls the dimmer switch of a city? Civic technologists argue that these systems must be transparent and modular to avoid a new class divide between biologically-aligned neighborhoods and everyone else.'
+    ],
+    category: 'Future Cities',
+    readTime: '7 min read',
+    publishedAt: '2 hours ago',
+    mood: 'hero',
+    accent: '#f67280',
+    gradient: 'linear-gradient(135deg, rgba(246, 114, 128, 0.9), rgba(192, 108, 132, 0.65))'
+  },
+  {
+    slug: 'wiki-rewilding',
+    title: 'Rewilding Wikipedia with Generative Stewardship',
+    excerpt:
+      'Volunteer editors are enlisting AI partners to rehabilitate neglected knowledge ecosystems without erasing human nuance.',
+    content: [
+      'Hyper-niche communities are turning Wikipedia stubs into lush, multimedia gardens. Instead of letting bots run wild, curators are pairing generative systems with review circles to preserve tone, citations, and lived context.',
+      'The hybrid workflow mirrors ecological stewardship: algorithms propose seedlings of content, while humans prune, translate, and prioritize based on cultural sensitivity. The result is an encyclopedic canopy that resists homogeneity.',
+      'Our playbook outlines how to evaluate synthetic contributions, mentor new editors, and structure transparency reports that keep trust intact.'
+    ],
+    category: 'Knowledge Systems',
+    readTime: '5 min read',
+    publishedAt: '4 hours ago',
+    mood: 'feature',
+    accent: '#c06c84',
+    gradient: 'linear-gradient(135deg, rgba(192, 108, 132, 0.85), rgba(108, 91, 123, 0.6))'
+  },
+  {
+    slug: 'climate-soundtracks',
+    title: 'Climate Soundtracks for the Circular Economy',
+    excerpt:
+      'Composers and manufacturers are syncing audio identities to recycled materials to reveal hidden loops in supply chains.',
+    content: [
+      'Circular economy brands have always needed better storytelling. By publishing sonic signatures tied to material provenance, designers are helping consumers sense the loops embedded in everyday objects.',
+      'We toured three factories that choreograph sound cues with every reclaimed batch. The experience feels like a living score where each instrument is a diverted waste stream.',
+      'The approach could scale beyond marketing: regulators are experimenting with acoustic disclosures that alert communities when pollution thresholds near critical limits.'
+    ],
+    category: 'Climate & Culture',
+    readTime: '6 min read',
+    publishedAt: 'Yesterday',
+    mood: 'feature',
+    accent: '#6c5b7b',
+    gradient: 'linear-gradient(140deg, rgba(108, 91, 123, 0.85), rgba(53, 92, 125, 0.7))'
+  },
+  {
+    slug: 'microstudio-renaissance',
+    title: 'The Microstudio Renaissance Is Fueling Solo Inventors',
+    excerpt:
+      'Compact lab lofts are equipping independent builders with cinematic tools and biotech rigs in one membership.',
+    content: [
+      'Membership microstudios used to be glorified co-working pods. The new wave blends fabrication bays, podcast caves, and wet labs for $300 a month.',
+      'We interviewed six founders whose ventures went from sketch to prototype without leaving a single block. The key unlock? Shared compliance teams who bake regulatory hygiene into every workstation.',
+      'For cities courting builders, microstudios are becoming civic infrastructure — a place to pilot policies in weeks instead of years.'
+    ],
+    category: 'Creator Economy',
+    readTime: '4 min read',
+    publishedAt: 'Yesterday',
+    mood: 'quick',
+    accent: '#355c7d',
+    gradient: 'linear-gradient(135deg, rgba(53, 92, 125, 0.85), rgba(250, 209, 181, 0.9))'
+  },
+  {
+    slug: 'intimate-ai-interfaces',
+    title: 'Intimate AI Interfaces for Boutique Healthcare',
+    excerpt:
+      'Concierge clinics are building bedside agents that whisper insights without hijacking human rapport.',
+    content: [
+      'Healthcare startups are finally ditching sterile dashboards. Boutique clinics now favor ambient projection, haptics, and biometrics woven into warm, tactile experiences.',
+      'Lantern Logic designers co-created a bedside agent that surfaces metrics as woven light patterns along the headboard. Patients reported a 30% drop in tech anxiety.',
+      'We share prototyping tips for maintaining consent, grounding, and the human-to-human attention that matters most.'
+    ],
+    category: 'Human-Centered AI',
+    readTime: '8 min read',
+    publishedAt: '2 days ago',
+    mood: 'quick',
+    accent: '#f67280',
+    gradient: 'linear-gradient(150deg, rgba(250, 209, 181, 0.9), rgba(246, 114, 128, 0.7))'
+  },
+  {
+    slug: 'astro-archive',
+    title: 'Archiving the Night Sky for the Post-Satellite Era',
+    excerpt:
+      'Astronomers are racing to capture dark-sky panoramas before orbit turns into a permanent light show.',
+    content: [
+      'With megaconstellations multiplying, dark-sky preserves are accelerating efforts to capture pristine celestial baselines.',
+      'An international coalition is building an encrypted, community-owned archive of night-sky footage to inform future spectrum policy.',
+      'The archive doubles as an immersive art platform, letting people experience ancient starlight through volumetric domes.'
+    ],
+    category: 'Space Futures',
+    readTime: '9 min read',
+    publishedAt: 'Last week',
+    mood: 'quick',
+    accent: '#355c7d',
+    gradient: 'linear-gradient(140deg, rgba(53, 92, 125, 0.9), rgba(108, 91, 123, 0.65))'
+  }
+];
+
+export function getPost(slug: string) {
+  return posts.find((post) => post.slug === slug);
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -6,9 +6,10 @@ export interface Post {
   category: string;
   readTime: string;
   publishedAt: string;
-  mood: 'hero' | 'feature' | 'quick';
+  mood: 'hero' | 'feature' | 'dispatch' | 'quick';
   accent: string;
   gradient: string;
+  coverImage: string;
 }
 
 export const posts: Post[] = [
@@ -27,7 +28,8 @@ export const posts: Post[] = [
     publishedAt: '2 hours ago',
     mood: 'hero',
     accent: '#f67280',
-    gradient: 'linear-gradient(135deg, rgba(246, 114, 128, 0.9), rgba(192, 108, 132, 0.65))'
+    gradient: 'linear-gradient(135deg, rgba(246, 114, 128, 0.9), rgba(192, 108, 132, 0.65))',
+    coverImage: 'https://images.unsplash.com/photo-1523755231516-e43fd2e8dca5?auto=format&fit=crop&w=1600&q=80'
   },
   {
     slug: 'wiki-rewilding',
@@ -44,7 +46,8 @@ export const posts: Post[] = [
     publishedAt: '4 hours ago',
     mood: 'feature',
     accent: '#c06c84',
-    gradient: 'linear-gradient(135deg, rgba(192, 108, 132, 0.85), rgba(108, 91, 123, 0.6))'
+    gradient: 'linear-gradient(135deg, rgba(192, 108, 132, 0.85), rgba(108, 91, 123, 0.6))',
+    coverImage: 'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?auto=format&fit=crop&w=1400&q=80'
   },
   {
     slug: 'climate-soundtracks',
@@ -61,7 +64,44 @@ export const posts: Post[] = [
     publishedAt: 'Yesterday',
     mood: 'feature',
     accent: '#6c5b7b',
-    gradient: 'linear-gradient(140deg, rgba(108, 91, 123, 0.85), rgba(53, 92, 125, 0.7))'
+    gradient: 'linear-gradient(140deg, rgba(108, 91, 123, 0.85), rgba(53, 92, 125, 0.7))',
+    coverImage: 'https://images.unsplash.com/photo-1514525253161-7a46d19cd819?auto=format&fit=crop&w=1400&q=80'
+  },
+  {
+    slug: 'immersive-transit-lounges',
+    title: 'Immersive Transit Lounges Reset the Commuter Ritual',
+    excerpt:
+      'Airports are rehabbing empty concourses into restorative galleries where biometrics melt into ambient art.',
+    content: [
+      'The post-pandemic travel surge exposed how utilitarian concourses actually drain productivity. A new class of “calm tech” transit lounges swaps departure boards for reactive murals that stream live transit data only when you need it.',
+      'Lantern Logic partnered with Nordic airport designers to prototype a modular lounge kit. Each bay pairs scent, light, and adaptive audio to match chronotypes. Travelers opt-in by tapping a tactile tile — no apps, no friction.',
+      'Results from the pilot show a 40% uptick in passenger satisfaction scores. We break down the materials library and data ethics guardrails that keep the system human-first.'
+    ],
+    category: 'Mobility Futures',
+    readTime: '6 min read',
+    publishedAt: 'Today',
+    mood: 'feature',
+    accent: '#355c7d',
+    gradient: 'linear-gradient(145deg, rgba(53, 92, 125, 0.85), rgba(250, 209, 181, 0.78))',
+    coverImage: 'https://images.unsplash.com/photo-1521721137577-22ad38b3ec0f?auto=format&fit=crop&w=1400&q=80'
+  },
+  {
+    slug: 'tidal-grid-briefing',
+    title: 'Dispatch: Inside the North Sea’s Tidal Grid Accelerator',
+    excerpt:
+      'Our field team documents how modular turbines, fishing cooperatives, and indigenous stewards are co-designing Europe’s cleanest megaproject.',
+    content: [
+      'The Tidal Grid Accelerator is part lab, part living reef. Over the past six months we have embedded with marine engineers and coastal cooperatives aligning on a single mandate: center biodiversity while scaling renewable output.',
+      'This dispatch shares sketches from the offshore control rooms, interviews with the Skagerrak fisheries who steward the waters, and a primer on how the accelerator’s open IP clauses could reset the politics of infrastructure.',
+      'We close with a toolkit for civic teams hoping to adapt the model to other archipelagos without repeating colonial extraction patterns.'
+    ],
+    category: 'Field Dispatch',
+    readTime: '12 min read',
+    publishedAt: 'Today',
+    mood: 'dispatch',
+    accent: '#f67280',
+    gradient: 'linear-gradient(160deg, rgba(246, 114, 128, 0.85), rgba(192, 108, 132, 0.65))',
+    coverImage: 'https://images.unsplash.com/photo-1477414348463-c0eb7f1359b6?auto=format&fit=crop&w=1200&q=80'
   },
   {
     slug: 'microstudio-renaissance',
@@ -78,7 +118,8 @@ export const posts: Post[] = [
     publishedAt: 'Yesterday',
     mood: 'quick',
     accent: '#355c7d',
-    gradient: 'linear-gradient(135deg, rgba(53, 92, 125, 0.85), rgba(250, 209, 181, 0.9))'
+    gradient: 'linear-gradient(135deg, rgba(53, 92, 125, 0.85), rgba(250, 209, 181, 0.9))',
+    coverImage: 'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80'
   },
   {
     slug: 'intimate-ai-interfaces',
@@ -95,7 +136,26 @@ export const posts: Post[] = [
     publishedAt: '2 days ago',
     mood: 'quick',
     accent: '#f67280',
-    gradient: 'linear-gradient(150deg, rgba(250, 209, 181, 0.9), rgba(246, 114, 128, 0.7))'
+    gradient: 'linear-gradient(150deg, rgba(250, 209, 181, 0.9), rgba(246, 114, 128, 0.7))',
+    coverImage: 'https://images.unsplash.com/photo-1601934823311-d1599c5ef8c6?auto=format&fit=crop&w=1200&q=80'
+  },
+  {
+    slug: 'kinetic-campus-labs',
+    title: 'Dispatch: Kinetic Campus Labs Rewrite Research Workflows',
+    excerpt:
+      'A tour of mixed-reality studios at three universities experimenting with kinetic walls, responsive light, and cohort-based protocols.',
+    content: [
+      'Kinetic labs blur the line between architecture and instrumentation. We spent two weeks moving with cohort teams at three universities who choreograph their research across rooms that literally reshape themselves every hour.',
+      'The rooms remember each cohort’s sequence. When environmental scientists roll in, the wall LEDs dim to circadian-safe amber. When performance technologists take over, the same walls ripple to become motion-capture canvases.',
+      'This dispatch dissects how facilities managers budget for modular hardware, the governance structures that determine access, and why the students call it “studying inside a living organism.”'
+    ],
+    category: 'Field Dispatch',
+    readTime: '10 min read',
+    publishedAt: '2 days ago',
+    mood: 'dispatch',
+    accent: '#6c5b7b',
+    gradient: 'linear-gradient(140deg, rgba(108, 91, 123, 0.88), rgba(53, 92, 125, 0.7))',
+    coverImage: 'https://images.unsplash.com/photo-1526498460520-4c246339dccb?auto=format&fit=crop&w=1200&q=80'
   },
   {
     slug: 'astro-archive',
@@ -112,7 +172,44 @@ export const posts: Post[] = [
     publishedAt: 'Last week',
     mood: 'quick',
     accent: '#355c7d',
-    gradient: 'linear-gradient(140deg, rgba(53, 92, 125, 0.9), rgba(108, 91, 123, 0.65))'
+    gradient: 'linear-gradient(140deg, rgba(53, 92, 125, 0.9), rgba(108, 91, 123, 0.65))',
+    coverImage: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80'
+  },
+  {
+    slug: 'luminous-wildcards',
+    title: 'Luminous Wildcards Illuminate Climate Scenarios',
+    excerpt:
+      'Scenario planners are training projection orbs to glow with probabilities, giving city councils a tactile way to debate futures.',
+    content: [
+      'A consortium of civic futurists has introduced Luminous Wildcards — translucent orbs that encode data about climate tipping points. When a scenario becomes more likely, the orb brightens and shifts hue.',
+      'The system lives in public briefing rooms where residents can literally grasp the stakes. It pairs with open dashboards so constituents can audit assumptions in real time.',
+      'Policy teams say the tactile layer keeps debate grounded. We outline a starter kit for building your own luminous library with off-the-shelf LEDs and open climate models.'
+    ],
+    category: 'Civic Tech',
+    readTime: '3 min read',
+    publishedAt: 'Last week',
+    mood: 'quick',
+    accent: '#f67280',
+    gradient: 'linear-gradient(145deg, rgba(246, 114, 128, 0.85), rgba(250, 209, 181, 0.85))',
+    coverImage: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80'
+  },
+  {
+    slug: 'sensorial-supply-chains',
+    title: 'Climate Retailers Map Sensorial Supply Chains',
+    excerpt:
+      'Experiential stores are teaching buyers to taste, hear, and feel recycled content before it ever hits the shelves.',
+    content: [
+      'Retailers obsessed with circularity are finally getting better show-and-tell tools. We profile the sensorial labs inside three flagship stores that guide shoppers through the lifecycle of every garment.',
+      'By translating emission data into tactile samples and spatial audio, sustainability officers are seeing conversion lifts without resorting to greenwashing.',
+      'The piece ends with a blueprint for building your own sensorial chain walkthrough with off-the-shelf components.'
+    ],
+    category: 'Climate & Culture',
+    readTime: '7 min read',
+    publishedAt: 'Last week',
+    mood: 'feature',
+    accent: '#c06c84',
+    gradient: 'linear-gradient(150deg, rgba(192, 108, 132, 0.85), rgba(246, 114, 128, 0.6))',
+    coverImage: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=80'
   }
 ];
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "lantern-logic-blog",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.8.10",
+    "@types/react": "18.2.28",
+    "@types/react-dom": "18.2.13",
+    "eslint": "8.53.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "5.2.2"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,15 @@
+import type { AppProps } from 'next/app';
+import Head from 'next/head';
+import '@/styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Lantern Logic Journal</title>
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
+}

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -1,0 +1,56 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import BlogHeader from '@/components/BlogHeader';
+import styles from '@/styles/PostPage.module.css';
+import { getPost } from '@/lib/posts';
+
+export default function PostPage() {
+  const {
+    query: { slug }
+  } = useRouter();
+  const post = typeof slug === 'string' ? getPost(slug) : undefined;
+
+  if (!post) {
+    return (
+      <div className={styles.missing}>
+        <p>Loading story…</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{post.title} — Lantern Logic Journal</title>
+        <meta name="description" content={post.excerpt} />
+      </Head>
+      <div className={styles.wrapper}>
+        <BlogHeader />
+        <article className={styles.article}>
+          <header className={styles.hero} style={{ backgroundImage: post.gradient }}>
+            <div className={styles.heroInner}>
+              <span className={styles.pill}>{post.category}</span>
+              <h1>{post.title}</h1>
+              <div className={styles.metaRow}>
+                <span>{post.publishedAt}</span>
+                <span>•</span>
+                <span>{post.readTime}</span>
+              </div>
+            </div>
+          </header>
+          <div className={styles.body}>
+            {post.content.map((paragraph, index) => (
+              <p key={index}>{paragraph}</p>
+            ))}
+          </div>
+          <footer className={styles.footer}>
+            <Link href="/blog" className={styles.backLink}>
+              ← Back to all stories
+            </Link>
+          </footer>
+        </article>
+      </div>
+    </>
+  );
+}

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -28,7 +28,10 @@ export default function PostPage() {
       <div className={styles.wrapper}>
         <BlogHeader />
         <article className={styles.article}>
-          <header className={styles.hero} style={{ backgroundImage: post.gradient }}>
+          <header
+            className={styles.hero}
+            style={{ backgroundImage: `${post.gradient}, url(${post.coverImage})` }}
+          >
             <div className={styles.heroInner}>
               <span className={styles.pill}>{post.category}</span>
               <h1>{post.title}</h1>

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -6,6 +6,7 @@ import { posts } from '@/lib/posts';
 
 const heroPost = posts.find((post) => post.mood === 'hero');
 const featurePosts = posts.filter((post) => post.mood === 'feature');
+const dispatchPosts = posts.filter((post) => post.mood === 'dispatch');
 const quickPosts = posts.filter((post) => post.mood === 'quick');
 
 export default function BlogIndex() {
@@ -22,7 +23,11 @@ export default function BlogIndex() {
         <BlogHeader />
         <main className={styles.main}>
           {heroPost && (
-            <article className={styles.hero} style={{ backgroundImage: heroPost.gradient }}>
+            <article
+              id="spotlight"
+              className={styles.hero}
+              style={{ backgroundImage: `${heroPost.gradient}, url(${heroPost.coverImage})` }}
+            >
               <div className={styles.heroInner}>
                 <span className={styles.pill}>{heroPost.category}</span>
                 <Link href={`/blog/${heroPost.slug}`} className={styles.heroLink}>
@@ -38,44 +43,87 @@ export default function BlogIndex() {
             </article>
           )}
 
-          <section id="features" className={styles.featureGrid}>
-            {featurePosts.map((post) => (
-              <article key={post.slug} className={styles.featureCard} style={{ backgroundImage: post.gradient }}>
-                <div className={styles.featureInner}>
-                  <span className={styles.pill}>{post.category}</span>
-                  <Link href={`/blog/${post.slug}`} className={styles.featureLink}>
-                    <h2>{post.title}</h2>
-                  </Link>
-                  <p>{post.excerpt}</p>
-                  <div className={styles.metaRow}>
-                    <span>{post.publishedAt}</span>
-                    <span>•</span>
-                    <span>{post.readTime}</span>
+          {(featurePosts.length > 0 || dispatchPosts.length > 0) && (
+            <div className={styles.editorialRow}>
+              {featurePosts.length > 0 && (
+                <section id="features" className={styles.featureSection} aria-labelledby="top-stories-heading">
+                  <header className={styles.sectionHeading}>
+                    <h2 id="top-stories-heading">Top stories</h2>
+                    <p>Immersive reporting, speculative design, and climate creativity.</p>
+                  </header>
+                  <div className={styles.featureMosaic}>
+                    {featurePosts.map((post, index) => (
+                      <article
+                        key={post.slug}
+                        className={`${styles.featureCard} ${index === 0 ? styles.featureCardLarge : ''}`}
+                        style={{ backgroundImage: `${post.gradient}, url(${post.coverImage})` }}
+                      >
+                        <div className={styles.featureInner}>
+                          <span className={styles.pill}>{post.category}</span>
+                          <Link href={`/blog/${post.slug}`} className={styles.featureLink}>
+                            <h3>{post.title}</h3>
+                          </Link>
+                          <p>{post.excerpt}</p>
+                          <div className={styles.metaRow}>
+                            <span>{post.publishedAt}</span>
+                            <span aria-hidden="true">•</span>
+                            <span>{post.readTime}</span>
+                          </div>
+                        </div>
+                      </article>
+                    ))}
                   </div>
-                </div>
-              </article>
-            ))}
-          </section>
+                </section>
+              )}
 
-          <section id="signals" className={styles.signalPanel}>
-            <header className={styles.sectionHeader}>
-              <h3>Signals</h3>
-              <p>Quick pulses on emerging tech, climate, and culture.</p>
-            </header>
-            <div className={styles.signalList}>
-              {quickPosts.map((post) => (
-                <Link key={post.slug} href={`/blog/${post.slug}`} className={styles.signalItem}>
-                  <span className={styles.signalAccent} style={{ background: post.accent }} />
-                  <div>
-                    <p className={styles.signalTitle}>{post.title}</p>
-                    <p className={styles.signalMeta}>
-                      {post.category} • {post.readTime}
-                    </p>
+              {dispatchPosts.length > 0 && (
+                <aside id="dispatches" className={styles.dispatchSection} aria-labelledby="dispatches-heading">
+                  <header className={styles.sectionHeading}>
+                    <h2 id="dispatches-heading">Field dispatches</h2>
+                    <p>Firsthand notes from expeditions, labs, and civic pilots.</p>
+                  </header>
+                  <div className={styles.dispatchList}>
+                    {dispatchPosts.map((post) => (
+                      <Link key={post.slug} href={`/blog/${post.slug}`} className={styles.dispatchItem}>
+                        <span className={styles.dispatchAccent} style={{ background: post.accent }} aria-hidden="true" />
+                        <div>
+                          <p className={styles.dispatchTitle}>{post.title}</p>
+                          <p className={styles.dispatchMeta}>
+                            {post.publishedAt} • {post.readTime}
+                          </p>
+                        </div>
+                      </Link>
+                    ))}
                   </div>
-                </Link>
-              ))}
+                </aside>
+              )}
             </div>
-          </section>
+          )}
+
+          {quickPosts.length > 0 && (
+            <section id="signals" className={styles.signalSection} aria-labelledby="signals-heading">
+              <div className={styles.sectionHeading}>
+                <h2 id="signals-heading">Signal pulses</h2>
+                <p>Snap insights to share in your next standup or salon.</p>
+              </div>
+              <div className={styles.signalRail}>
+                {quickPosts.map((post) => (
+                  <article key={post.slug} className={styles.signalCard}>
+                    <span className={styles.signalAccent} style={{ background: post.accent }} aria-hidden="true" />
+                    <div className={styles.signalBody}>
+                      <Link href={`/blog/${post.slug}`} className={styles.signalTitle}>
+                        {post.title}
+                      </Link>
+                      <p className={styles.signalExcerpt}>{post.excerpt}</p>
+                      <p className={styles.signalMeta}>
+                        {post.category} • {post.readTime}
+                      </p>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+          )}
         </main>
       </div>
     </>

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -1,0 +1,83 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import BlogHeader from '@/components/BlogHeader';
+import styles from '@/styles/BlogIndex.module.css';
+import { posts } from '@/lib/posts';
+
+const heroPost = posts.find((post) => post.mood === 'hero');
+const featurePosts = posts.filter((post) => post.mood === 'feature');
+const quickPosts = posts.filter((post) => post.mood === 'quick');
+
+export default function BlogIndex() {
+  return (
+    <>
+      <Head>
+        <title>Lantern Logic Journal — Future-facing essays & signals</title>
+        <meta
+          name="description"
+          content="Lantern Logic Journal blends design culture, climate tech, and speculative futures in a modern magazine layout inspired by MIT Technology Review."
+        />
+      </Head>
+      <div className={styles.wrapper}>
+        <BlogHeader />
+        <main className={styles.main}>
+          {heroPost && (
+            <article className={styles.hero} style={{ backgroundImage: heroPost.gradient }}>
+              <div className={styles.heroInner}>
+                <span className={styles.pill}>{heroPost.category}</span>
+                <Link href={`/blog/${heroPost.slug}`} className={styles.heroLink}>
+                  <h1>{heroPost.title}</h1>
+                </Link>
+                <p>{heroPost.excerpt}</p>
+                <div className={styles.metaRow}>
+                  <span>{heroPost.publishedAt}</span>
+                  <span>•</span>
+                  <span>{heroPost.readTime}</span>
+                </div>
+              </div>
+            </article>
+          )}
+
+          <section id="features" className={styles.featureGrid}>
+            {featurePosts.map((post) => (
+              <article key={post.slug} className={styles.featureCard} style={{ backgroundImage: post.gradient }}>
+                <div className={styles.featureInner}>
+                  <span className={styles.pill}>{post.category}</span>
+                  <Link href={`/blog/${post.slug}`} className={styles.featureLink}>
+                    <h2>{post.title}</h2>
+                  </Link>
+                  <p>{post.excerpt}</p>
+                  <div className={styles.metaRow}>
+                    <span>{post.publishedAt}</span>
+                    <span>•</span>
+                    <span>{post.readTime}</span>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </section>
+
+          <section id="signals" className={styles.signalPanel}>
+            <header className={styles.sectionHeader}>
+              <h3>Signals</h3>
+              <p>Quick pulses on emerging tech, climate, and culture.</p>
+            </header>
+            <div className={styles.signalList}>
+              {quickPosts.map((post) => (
+                <Link key={post.slug} href={`/blog/${post.slug}`} className={styles.signalItem}>
+                  <span className={styles.signalAccent} style={{ background: post.accent }} />
+                  <div>
+                    <p className={styles.signalTitle}>{post.title}</p>
+                    <p className={styles.signalMeta}>
+                      {post.category} • {post.readTime}
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        </main>
+      </div>
+    </>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import styles from '@/styles/Landing.module.css';
+
+export default function LandingPage() {
+  return (
+    <main className={styles.page}>
+      <div className={styles.container}>
+        <div className={styles.eye}>SEE</div>
+        <div className={styles.sketchWrap}>
+          <div className={styles.sketch} aria-hidden />
+        </div>
+        <h1 className={styles.title}>Lantern Logic Journal</h1>
+        <p className={styles.subtitle}>
+          A curated stream of bright ideas, culture riffs, and the tech that&apos;s remaking tomorrow.
+          Step inside and stay awhile.
+        </p>
+        <Link href="/blog" legacyBehavior>
+          <a className={styles.enterButton}>Enter</a>
+        </Link>
+        <p className={styles.footerNote}>Copyright 2024 Lantern Logic Studio</p>
+      </div>
+    </main>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,8 +14,8 @@ export default function LandingPage() {
           A curated stream of bright ideas, culture riffs, and the tech that&apos;s remaking tomorrow.
           Step inside and stay awhile.
         </p>
-        <Link href="/blog" legacyBehavior>
-          <a className={styles.enterButton}>Enter</a>
+        <Link href="/blog" className={styles.enterButton}>
+          Enter
         </Link>
         <p className={styles.footerNote}>Copyright 2024 Lantern Logic Studio</p>
       </div>

--- a/styles/BlogHeader.module.css
+++ b/styles/BlogHeader.module.css
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 2rem 0 1rem;
-  border-bottom: 1px solid rgba(53, 92, 125, 0.2);
+  border-bottom: 1px solid rgba(39, 67, 92, 0.18);
   gap: 1.5rem;
 }
 
@@ -22,7 +22,7 @@
 .tagline {
   margin: 0;
   font-size: 0.95rem;
-  color: rgba(28, 28, 28, 0.7);
+  color: rgba(28, 28, 28, 0.65);
 }
 
 .nav {
@@ -45,7 +45,7 @@
   bottom: -0.35rem;
   width: 100%;
   height: 2px;
-  background: rgba(246, 114, 128, 0.6);
+  background: rgba(228, 127, 124, 0.55);
   transform: scaleX(0);
   transform-origin: left;
   transition: transform 0.2s ease;

--- a/styles/BlogHeader.module.css
+++ b/styles/BlogHeader.module.css
@@ -1,0 +1,76 @@
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2rem 0 1rem;
+  border-bottom: 1px solid rgba(53, 92, 125, 0.2);
+  gap: 1.5rem;
+}
+
+.branding {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.logo {
+  font-family: 'DM Serif Display', serif;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.tagline {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(28, 28, 28, 0.7);
+}
+
+.nav {
+  display: flex;
+  gap: 1.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+}
+
+.nav a {
+  position: relative;
+}
+
+.nav a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -0.35rem;
+  width: 100%;
+  height: 2px;
+  background: rgba(246, 114, 128, 0.6);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.2s ease;
+}
+
+.nav a:hover::after,
+.nav a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+@media (max-width: 768px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 520px) {
+  .nav {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+}

--- a/styles/BlogIndex.module.css
+++ b/styles/BlogIndex.module.css
@@ -1,230 +1,359 @@
 .wrapper {
   max-width: var(--max-width);
   margin: 0 auto;
-  padding: 0 1.5rem 4rem;
+  padding: 0 1.5rem 4.5rem;
 }
 
 .main {
   display: grid;
-  gap: 3rem;
-  padding-top: 2rem;
+  gap: 3.5rem;
+  padding-top: 2.5rem;
 }
 
 .hero {
-  border-radius: 28px;
-  padding: clamp(2rem, 4vw, 3.5rem);
-  color: #fff;
   position: relative;
-  overflow: hidden;
-  min-height: 420px;
   display: flex;
   align-items: flex-end;
-  box-shadow: 0 40px 90px rgba(30, 38, 55, 0.22);
+  min-height: 440px;
+  padding: clamp(2.5rem, 5vw, 3.75rem);
+  color: #fff;
+  border-radius: 32px;
+  overflow: hidden;
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 48px 110px rgba(30, 38, 55, 0.24);
+  isolation: isolate;
 }
 
 .hero::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 30% 20%, rgba(250, 209, 181, 0.25), transparent 55%);
-  mix-blend-mode: screen;
+  background: linear-gradient(160deg, rgba(17, 24, 39, 0.25), rgba(17, 24, 39, 0.7));
+  mix-blend-mode: multiply;
+  z-index: -1;
 }
 
 .heroInner {
+  display: grid;
+  gap: 1.1rem;
+  max-width: 580px;
   position: relative;
   z-index: 1;
-  max-width: 540px;
-  display: grid;
-  gap: 1rem;
+}
+
+.heroLink {
+  text-decoration: none;
+  color: inherit;
 }
 
 .heroInner h1 {
-  font-size: clamp(2.2rem, 5vw, 3.6rem);
   margin: 0;
+  font-size: clamp(2.4rem, 6vw, 3.9rem);
   line-height: 1.05;
+  letter-spacing: -0.01em;
 }
 
 .heroInner p {
   margin: 0;
-  font-size: 1.05rem;
-  line-height: 1.6;
+  font-size: 1.1rem;
+  line-height: 1.7;
 }
 
 .pill {
   display: inline-block;
+  width: fit-content;
+  padding: 0.45rem 1.1rem;
   font-size: 0.75rem;
   text-transform: uppercase;
-  letter-spacing: 0.2em;
-  padding: 0.4rem 1rem;
+  letter-spacing: 0.22em;
   border-radius: 999px;
-  background: rgba(250, 209, 181, 0.25);
-  color: #fff;
+  background: rgba(250, 209, 181, 0.35);
+  color: inherit;
   font-weight: 600;
-  width: fit-content;
 }
 
 .metaRow {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.55rem;
   align-items: center;
-  font-size: 0.85rem;
-  opacity: 0.9;
+  font-size: 0.9rem;
+  opacity: 0.92;
 }
 
-.featureGrid {
+.editorialRow {
   display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr) minmax(0, 360px);
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.sectionHeading {
+  display: grid;
+  gap: 0.4rem;
+  margin-bottom: 1.75rem;
+}
+
+.sectionHeading h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.sectionHeading p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(28, 28, 28, 0.7);
+}
+
+.featureSection {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.featureMosaic {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
 }
 
 .featureCard {
-  border-radius: 24px;
-  min-height: 320px;
+  position: relative;
   display: flex;
   align-items: flex-end;
+  min-height: 320px;
+  padding: 2.4rem;
   color: #fff;
-  padding: 2.5rem;
-  position: relative;
+  border-radius: 28px;
   overflow: hidden;
-  box-shadow: 0 28px 70px rgba(30, 38, 55, 0.18);
+  background-size: cover;
+  background-position: center;
+  box-shadow: 0 36px 90px rgba(30, 38, 55, 0.2);
+  isolation: isolate;
+  grid-column: span 3;
 }
 
 .featureCard::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 80% 15%, rgba(250, 209, 181, 0.22), transparent 60%);
-  mix-blend-mode: screen;
+  background: linear-gradient(180deg, rgba(17, 24, 39, 0.1), rgba(17, 24, 39, 0.75));
+  mix-blend-mode: multiply;
+  z-index: -1;
+}
+
+.featureCardLarge {
+  grid-column: span 4;
+  min-height: 360px;
 }
 
 .featureInner {
+  display: grid;
+  gap: 0.8rem;
   position: relative;
   z-index: 1;
-  display: grid;
-  gap: 0.75rem;
 }
 
-.featureInner h2 {
+.featureInner h3 {
   margin: 0;
-  font-size: clamp(1.6rem, 3vw, 2.3rem);
+  font-size: clamp(1.6rem, 3.5vw, 2.35rem);
+  line-height: 1.15;
 }
 
 .featureInner p {
   margin: 0;
-  line-height: 1.6;
+  line-height: 1.65;
 }
 
-.sectionHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+.featureLink {
+  text-decoration: none;
+  color: inherit;
 }
 
-.sectionHeader h3 {
-  margin: 0;
-  font-size: 1.1rem;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-}
-
-.sectionHeader p {
-  margin: 0;
-  max-width: 360px;
-  font-size: 0.95rem;
-  color: rgba(28, 28, 28, 0.7);
-}
-
-.signalPanel {
-  background: rgba(255, 255, 255, 0.5);
-  border-radius: 24px;
-  padding: 2.5rem 2rem;
-  box-shadow: inset 0 0 0 1px rgba(53, 92, 125, 0.1);
-  backdrop-filter: blur(6px);
-}
-
-.signalList {
+.dispatchSection {
+  background: rgba(255, 255, 255, 0.62);
+  border-radius: 28px;
+  padding: 2.2rem 2rem;
+  box-shadow: inset 0 0 0 1px rgba(53, 92, 125, 0.12);
+  backdrop-filter: blur(8px);
   display: grid;
-  gap: 1.25rem;
+  gap: 1.5rem;
 }
 
-.signalItem {
+.dispatchList {
   display: grid;
-  grid-template-columns: 16px 1fr;
   gap: 1rem;
-  align-items: center;
+}
+
+.dispatchItem {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  gap: 1rem;
+  align-items: flex-start;
   padding-bottom: 1rem;
-  border-bottom: 1px solid rgba(53, 92, 125, 0.15);
-  transition: transform 0.2s ease;
+  border-bottom: 1px solid rgba(53, 92, 125, 0.18);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+  text-decoration: none;
+  color: inherit;
 }
 
-.signalItem:last-of-type {
+.dispatchItem:last-of-type {
   border-bottom: none;
   padding-bottom: 0;
 }
 
-.signalItem:hover {
+.dispatchItem:hover {
   transform: translateX(6px);
+  opacity: 0.9;
 }
 
-.signalAccent {
-  width: 16px;
-  height: 16px;
-  border-radius: 4px;
+.dispatchAccent {
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  margin-top: 0.3rem;
 }
 
-.signalTitle {
+.dispatchTitle {
   margin: 0;
   font-weight: 600;
+  line-height: 1.45;
 }
 
-.signalMeta {
-  margin: 0.35rem 0 0;
+.dispatchMeta {
+  margin: 0.45rem 0 0;
   font-size: 0.85rem;
   color: rgba(28, 28, 28, 0.65);
 }
 
-@media (max-width: 960px) {
-  .featureGrid {
-    grid-template-columns: 1fr;
+.signalSection {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 30px;
+  padding: 2.4rem 2.1rem 2.6rem;
+  box-shadow: inset 0 0 0 1px rgba(53, 92, 125, 0.1);
+  backdrop-filter: blur(8px);
+  display: grid;
+  gap: 1.75rem;
+}
+
+.signalRail {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.signalCard {
+  background: rgba(250, 209, 181, 0.18);
+  border-radius: 22px;
+  padding: 1.5rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  box-shadow: 0 24px 50px rgba(30, 38, 55, 0.12);
+}
+
+.signalAccent {
+  width: 14px;
+  height: 100%;
+  border-radius: 999px;
+}
+
+.signalBody {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.signalTitle {
+  font-weight: 600;
+  line-height: 1.35;
+  color: var(--color-navy);
+  text-decoration: none;
+}
+
+.signalTitle:hover {
+  text-decoration: underline;
+}
+
+.signalExcerpt {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(28, 28, 28, 0.78);
+}
+
+.signalMeta {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(28, 28, 28, 0.55);
+}
+
+@media (max-width: 1180px) {
+  .featureMosaic {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .featureCardLarge {
+    grid-column: span 4;
   }
 
   .featureCard {
-    min-height: 280px;
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 960px) {
+  .wrapper {
+    padding: 0 1.25rem 3.75rem;
+  }
+
+  .editorialRow {
+    grid-template-columns: 1fr;
+  }
+
+  .dispatchSection {
+    order: -1;
   }
 }
 
 @media (max-width: 720px) {
-  .wrapper {
-    padding: 0 1.25rem 3rem;
-  }
-
   .main {
-    gap: 2.25rem;
+    gap: 3rem;
   }
 
   .hero {
     min-height: 360px;
-    padding: 2.5rem;
+    padding: 2.25rem;
+  }
+
+  .featureMosaic {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .featureCard,
+  .featureCardLarge {
+    grid-column: span 2;
+    min-height: 280px;
+  }
+
+  .signalRail {
+    grid-template-columns: 1fr;
   }
 }
 
-@media (max-width: 540px) {
+@media (max-width: 520px) {
   .hero {
     padding: 2rem;
   }
 
-  .featureCard {
-    padding: 2rem;
+  .dispatchSection {
+    padding: 2rem 1.6rem;
   }
 
-  .signalPanel {
-    padding: 2rem 1.5rem;
-  }
-
-  .sectionHeader {
-    flex-direction: column;
-    align-items: flex-start;
+  .signalSection {
+    padding: 2rem 1.6rem;
   }
 }

--- a/styles/BlogIndex.module.css
+++ b/styles/BlogIndex.module.css
@@ -1,0 +1,230 @@
+.wrapper {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+}
+
+.main {
+  display: grid;
+  gap: 3rem;
+  padding-top: 2rem;
+}
+
+.hero {
+  border-radius: 28px;
+  padding: clamp(2rem, 4vw, 3.5rem);
+  color: #fff;
+  position: relative;
+  overflow: hidden;
+  min-height: 420px;
+  display: flex;
+  align-items: flex-end;
+  box-shadow: 0 40px 90px rgba(30, 38, 55, 0.22);
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 20%, rgba(250, 209, 181, 0.25), transparent 55%);
+  mix-blend-mode: screen;
+}
+
+.heroInner {
+  position: relative;
+  z-index: 1;
+  max-width: 540px;
+  display: grid;
+  gap: 1rem;
+}
+
+.heroInner h1 {
+  font-size: clamp(2.2rem, 5vw, 3.6rem);
+  margin: 0;
+  line-height: 1.05;
+}
+
+.heroInner p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.pill {
+  display: inline-block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  background: rgba(250, 209, 181, 0.25);
+  color: #fff;
+  font-weight: 600;
+  width: fit-content;
+}
+
+.metaRow {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.featureGrid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.featureCard {
+  border-radius: 24px;
+  min-height: 320px;
+  display: flex;
+  align-items: flex-end;
+  color: #fff;
+  padding: 2.5rem;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 28px 70px rgba(30, 38, 55, 0.18);
+}
+
+.featureCard::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 15%, rgba(250, 209, 181, 0.22), transparent 60%);
+  mix-blend-mode: screen;
+}
+
+.featureInner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.featureInner h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.3rem);
+}
+
+.featureInner p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.sectionHeader h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.sectionHeader p {
+  margin: 0;
+  max-width: 360px;
+  font-size: 0.95rem;
+  color: rgba(28, 28, 28, 0.7);
+}
+
+.signalPanel {
+  background: rgba(255, 255, 255, 0.5);
+  border-radius: 24px;
+  padding: 2.5rem 2rem;
+  box-shadow: inset 0 0 0 1px rgba(53, 92, 125, 0.1);
+  backdrop-filter: blur(6px);
+}
+
+.signalList {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.signalItem {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  gap: 1rem;
+  align-items: center;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(53, 92, 125, 0.15);
+  transition: transform 0.2s ease;
+}
+
+.signalItem:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.signalItem:hover {
+  transform: translateX(6px);
+}
+
+.signalAccent {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+}
+
+.signalTitle {
+  margin: 0;
+  font-weight: 600;
+}
+
+.signalMeta {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(28, 28, 28, 0.65);
+}
+
+@media (max-width: 960px) {
+  .featureGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .featureCard {
+    min-height: 280px;
+  }
+}
+
+@media (max-width: 720px) {
+  .wrapper {
+    padding: 0 1.25rem 3rem;
+  }
+
+  .main {
+    gap: 2.25rem;
+  }
+
+  .hero {
+    min-height: 360px;
+    padding: 2.5rem;
+  }
+}
+
+@media (max-width: 540px) {
+  .hero {
+    padding: 2rem;
+  }
+
+  .featureCard {
+    padding: 2rem;
+  }
+
+  .signalPanel {
+    padding: 2rem 1.5rem;
+  }
+
+  .sectionHeader {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/styles/Landing.module.css
+++ b/styles/Landing.module.css
@@ -1,0 +1,140 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at 15% 20%, rgba(246, 114, 128, 0.4), transparent 45%),
+    radial-gradient(circle at 85% 25%, rgba(192, 108, 132, 0.45), transparent 50%),
+    linear-gradient(160deg, var(--color-navy), var(--color-beige));
+  padding: 2rem;
+}
+
+.container {
+  max-width: 540px;
+  width: 100%;
+  background: rgba(250, 209, 181, 0.85);
+  border-radius: 28px;
+  border: 2px solid rgba(53, 92, 125, 0.45);
+  box-shadow: 0 30px 90px rgba(30, 38, 55, 0.28);
+  padding: 3.5rem 3rem;
+  backdrop-filter: blur(8px);
+  position: relative;
+  text-align: center;
+}
+
+.sketchWrap {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2.5rem;
+}
+
+.sketch {
+  width: 180px;
+  height: 180px;
+  background: radial-gradient(circle at 40% 30%, rgba(246, 114, 128, 0.45), rgba(192, 108, 132, 0.2) 60%, transparent 80%);
+  border: 2px dashed rgba(53, 92, 125, 0.55);
+  border-radius: 28% 34% 30% 35% / 40% 35% 30% 32%;
+  position: relative;
+}
+
+.sketch::before,
+.sketch::after {
+  content: '';
+  position: absolute;
+  background: rgba(53, 92, 125, 0.8);
+  border-radius: 999px;
+}
+
+.sketch::before {
+  width: 26px;
+  height: 26px;
+  top: 28%;
+  left: 20%;
+  box-shadow: 40px 12px 0 2px rgba(53, 92, 125, 0.8);
+}
+
+.sketch::after {
+  width: 18px;
+  height: 56px;
+  bottom: 18%;
+  left: 50%;
+  transform: translateX(-50%) rotate(18deg);
+  box-shadow: 35px -12px 0 -4px rgba(246, 114, 128, 0.9);
+}
+
+.eye {
+  position: absolute;
+  top: 18px;
+  right: 32px;
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 2px solid rgba(53, 92, 125, 0.8);
+  display: grid;
+  place-items: center;
+  font-family: 'DM Serif Display', serif;
+  font-size: 0.9rem;
+  letter-spacing: 0.18em;
+}
+
+.title {
+  font-family: 'DM Serif Display', serif;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  margin: 0 0 1rem;
+  letter-spacing: 0.05em;
+}
+
+.subtitle {
+  margin: 0 auto 2rem;
+  max-width: 360px;
+  line-height: 1.6;
+  font-size: 1rem;
+  color: rgba(28, 28, 28, 0.85);
+}
+
+.enterButton {
+  background: var(--color-coral);
+  color: #fff;
+  border: none;
+  padding: 0.85rem 2.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  cursor: pointer;
+  box-shadow: 0 18px 30px rgba(246, 114, 128, 0.32);
+}
+
+.enterButton:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 28px 46px rgba(192, 108, 132, 0.38);
+}
+
+.enterButton:active {
+  transform: translateY(0);
+}
+
+.footerNote {
+  margin-top: 2.5rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(28, 28, 28, 0.5);
+}
+
+@media (max-width: 600px) {
+  .container {
+    padding: 2.5rem 1.75rem 2.75rem;
+  }
+
+  .eye {
+    right: 18px;
+  }
+
+  .sketch {
+    width: 150px;
+    height: 150px;
+  }
+}

--- a/styles/Landing.module.css
+++ b/styles/Landing.module.css
@@ -3,8 +3,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: radial-gradient(circle at 15% 20%, rgba(246, 114, 128, 0.4), transparent 45%),
-    radial-gradient(circle at 85% 25%, rgba(192, 108, 132, 0.45), transparent 50%),
+  background: radial-gradient(circle at 15% 20%, rgba(228, 127, 124, 0.35), transparent 45%),
+    radial-gradient(circle at 85% 25%, rgba(185, 128, 163, 0.38), transparent 50%),
     linear-gradient(160deg, var(--color-navy), var(--color-beige));
   padding: 2rem;
 }
@@ -12,10 +12,10 @@
 .container {
   max-width: 540px;
   width: 100%;
-  background: rgba(250, 209, 181, 0.85);
-  border-radius: 28px;
-  border: 2px solid rgba(53, 92, 125, 0.45);
-  box-shadow: 0 30px 90px rgba(30, 38, 55, 0.28);
+  background: rgba(245, 239, 227, 0.88);
+  border-radius: 32px;
+  border: 2px solid rgba(39, 67, 92, 0.28);
+  box-shadow: 0 36px 95px rgba(30, 38, 55, 0.25);
   padding: 3.5rem 3rem;
   backdrop-filter: blur(8px);
   position: relative;
@@ -31,8 +31,8 @@
 .sketch {
   width: 180px;
   height: 180px;
-  background: radial-gradient(circle at 40% 30%, rgba(246, 114, 128, 0.45), rgba(192, 108, 132, 0.2) 60%, transparent 80%);
-  border: 2px dashed rgba(53, 92, 125, 0.55);
+  background: radial-gradient(circle at 40% 30%, rgba(228, 127, 124, 0.42), rgba(185, 128, 163, 0.18) 60%, transparent 80%);
+  border: 2px dashed rgba(39, 67, 92, 0.5);
   border-radius: 28% 34% 30% 35% / 40% 35% 30% 32%;
   position: relative;
 }
@@ -41,7 +41,7 @@
 .sketch::after {
   content: '';
   position: absolute;
-  background: rgba(53, 92, 125, 0.8);
+  background: rgba(39, 67, 92, 0.78);
   border-radius: 999px;
 }
 
@@ -50,7 +50,7 @@
   height: 26px;
   top: 28%;
   left: 20%;
-  box-shadow: 40px 12px 0 2px rgba(53, 92, 125, 0.8);
+  box-shadow: 40px 12px 0 2px rgba(39, 67, 92, 0.78);
 }
 
 .sketch::after {
@@ -59,7 +59,7 @@
   bottom: 18%;
   left: 50%;
   transform: translateX(-50%) rotate(18deg);
-  box-shadow: 35px -12px 0 -4px rgba(246, 114, 128, 0.9);
+  box-shadow: 35px -12px 0 -4px rgba(228, 127, 124, 0.86);
 }
 
 .eye {
@@ -69,7 +69,7 @@
   width: 46px;
   height: 46px;
   border-radius: 50%;
-  border: 2px solid rgba(53, 92, 125, 0.8);
+  border: 2px solid rgba(39, 67, 92, 0.75);
   display: grid;
   place-items: center;
   font-family: 'DM Serif Display', serif;
@@ -93,10 +93,13 @@
 }
 
 .enterButton {
-  background: var(--color-coral);
+  background: linear-gradient(120deg, var(--color-coral), var(--color-mauve));
   color: #fff;
   border: none;
   padding: 0.85rem 2.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 999px;
   font-weight: 600;
   font-size: 1rem;
@@ -104,12 +107,12 @@
   text-transform: uppercase;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
   cursor: pointer;
-  box-shadow: 0 18px 30px rgba(246, 114, 128, 0.32);
+  box-shadow: 0 18px 30px rgba(228, 127, 124, 0.32);
 }
 
 .enterButton:hover {
   transform: translateY(-4px) scale(1.02);
-  box-shadow: 0 28px 46px rgba(192, 108, 132, 0.38);
+  box-shadow: 0 28px 46px rgba(39, 67, 92, 0.25);
 }
 
 .enterButton:active {

--- a/styles/PostPage.module.css
+++ b/styles/PostPage.module.css
@@ -16,14 +16,18 @@
   padding: clamp(2.5rem, 4vw, 3.75rem);
   color: #fff;
   position: relative;
+  background-size: cover;
+  background-position: center;
+  overflow: hidden;
+  isolation: isolate;
 }
 
 .hero::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 20% 30%, rgba(250, 209, 181, 0.25), transparent 60%);
-  mix-blend-mode: screen;
+  background: linear-gradient(160deg, rgba(17, 24, 39, 0.25), rgba(17, 24, 39, 0.75));
+  mix-blend-mode: multiply;
 }
 
 .heroInner {

--- a/styles/PostPage.module.css
+++ b/styles/PostPage.module.css
@@ -1,0 +1,111 @@
+.wrapper {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+}
+
+.article {
+  margin-top: 2rem;
+  background: rgba(255, 255, 255, 0.58);
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: 0 30px 80px rgba(30, 38, 55, 0.16);
+}
+
+.hero {
+  padding: clamp(2.5rem, 4vw, 3.75rem);
+  color: #fff;
+  position: relative;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 30%, rgba(250, 209, 181, 0.25), transparent 60%);
+  mix-blend-mode: screen;
+}
+
+.heroInner {
+  position: relative;
+  z-index: 1;
+  max-width: 640px;
+  display: grid;
+  gap: 1rem;
+}
+
+.heroInner h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4.5vw, 3.4rem);
+  line-height: 1.05;
+}
+
+.pill {
+  display: inline-block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  background: rgba(250, 209, 181, 0.25);
+  color: #fff;
+  font-weight: 600;
+  width: fit-content;
+}
+
+.metaRow {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.9rem;
+}
+
+.body {
+  padding: clamp(2.5rem, 3.5vw, 3.5rem);
+  display: grid;
+  gap: 1.5rem;
+  font-size: 1.05rem;
+  line-height: 1.85;
+  color: rgba(28, 28, 28, 0.92);
+}
+
+.body p {
+  margin: 0;
+}
+
+.footer {
+  padding: 0 2.5rem 2.5rem;
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+  color: var(--color-navy);
+}
+
+.backLink:hover {
+  color: var(--color-plum);
+}
+
+.missing {
+  min-height: 60vh;
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+  color: rgba(28, 28, 28, 0.6);
+}
+
+@media (max-width: 640px) {
+  .wrapper {
+    padding: 0 1.25rem 3rem;
+  }
+
+  .footer {
+    padding: 0 1.75rem 2rem;
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,50 @@
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Serif+Display&display=swap');
+
+:root {
+  --color-beige: #fad1b5;
+  --color-coral: #f67280;
+  --color-mauve: #c06c84;
+  --color-plum: #6c5b7b;
+  --color-navy: #355c7d;
+  --color-text: #1c1c1c;
+  --max-width: 1200px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--color-text);
+  background-color: var(--color-beige);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+button {
+  font-family: inherit;
+}
+
+body {
+  min-height: 100vh;
+}
+
+:focus-visible {
+  outline: 3px solid var(--color-coral);
+  outline-offset: 4px;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,11 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Serif+Display&display=swap');
 
 :root {
-  --color-beige: #fad1b5;
-  --color-coral: #f67280;
-  --color-mauve: #c06c84;
-  --color-plum: #6c5b7b;
-  --color-navy: #355c7d;
+  --color-beige: #f5efe3;
+  --color-coral: #e47f7c;
+  --color-mauve: #b980a3;
+  --color-plum: #5e4c8c;
+  --color-navy: #27435c;
   --color-text: #1c1c1c;
   --max-width: 1200px;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a gatekeeper landing page with illustrated styling that links into the blog
- build a magazine-inspired blog index with hero, feature grid, and signal list cards populated from shared post data
- create individual post pages, responsive styling, shared header component, and project configuration

## Testing
- ⚠️ `npm install` *(fails: registry returned 403 Forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d51a0bea4c8325a7131e585be96b58